### PR TITLE
HIT-34297 Allow hard delete on contact resource

### DIFF
--- a/lib/freshdesk-rest/resource/contact.rb
+++ b/lib/freshdesk-rest/resource/contact.rb
@@ -32,6 +32,11 @@ module Freshdesk
         def delete(id:)
           Parser.parse(@client.delete("#{@path}/#{id}"))
         end
+
+        def hard_delete(id:, force: false)
+          force_params = force ? { force: true } : {}
+          Parser.parse(@client.delete(path_with_params([@path, id, 'hard_delete'], force_params)))
+        end
       end
     end
   end

--- a/lib/freshdesk-rest/version.rb
+++ b/lib/freshdesk-rest/version.rb
@@ -1,5 +1,5 @@
 module Freshdesk
   module Rest
-    VERSION = '0.1.5'
+    VERSION = '0.1.6'
   end
 end

--- a/spec/freshdesk-rest/resource/contact_spec.rb
+++ b/spec/freshdesk-rest/resource/contact_spec.rb
@@ -46,4 +46,27 @@ RSpec.describe Freshdesk::Rest::Resource::Contact do
 
     it { is_expected.to eq(result) }
   end
+
+  describe '#delete' do
+    before  { allow(api).to receive(:delete).with('/contacts/2015007548012').and_return(response) }
+    subject { service.delete(id: '2015007548012') }
+
+    it { is_expected.to eq(result) }
+  end
+
+  describe '#hard_delete' do
+    context 'without force' do
+      before  { allow(api).to receive(:delete).with('/contacts/2015007548012/hard_delete').and_return(response) }
+      subject { service.hard_delete(id: '2015007548012') }
+
+      it { is_expected.to eq(result) }
+    end
+
+    context 'with force' do
+      before  { allow(api).to receive(:delete).with('/contacts/2015007548012/hard_delete?force=true').and_return(response) }
+      subject { service.hard_delete(id: '2015007548012', force: true) }
+
+      it { is_expected.to eq(result) }
+    end
+  end
 end


### PR DESCRIPTION
https://helpling.atlassian.net/browse/HIT-34297

We need a way to hard delete contacts on H2.

For reference:
https://developers.freshdesk.com/api/#hard_delete_contact