### PR TITLE
Rename domain as subdomain

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A simple REST Freshdesk integration
 ## Requirements
 - Create a read-only API key in Freshdesk
 - Set an ENV var with `FRESHDESK_API_KEY`
-- Set an ENV var with `FRESHDESK_DOMAIN`
+- Set an ENV var with `FRESHDESK_SUBDOMAIN` ("fizbuz" if your Freshdesk domain is fizbuz.freshdesk.com)
 
 ## DISCLAIMER
 ### This is still a BETA!
@@ -17,7 +17,7 @@ Some of the methods signatures could change. I aim to keep always backward compa
 ```ruby
 Freshdesk::Rest.configure do |config|
   config.api_key = ENV['FRESHDESK_API_KEY']
-  config.domain = ENV['FRESHDESK_DOMAIN']
+  config.subdomain = ENV['FRESHDESK_SUBDOMAIN']
 end
 
 ```
@@ -33,7 +33,7 @@ freshdesk_client = Freshdesk::Rest::Client.new
 ```ruby
 freshdesk_client = Freshdesk::Rest::Client.new(
   api_key: ENV['FRESHDESK_API_KEY'],
-  domain: ENV['FRESHDESK_DOMAIN']
+  subdomain: ENV['FRESHDESK_SUBDOMAIN']
 )
 ```
 

--- a/lib/freshdesk-rest/api.rb
+++ b/lib/freshdesk-rest/api.rb
@@ -1,10 +1,10 @@
 module Freshdesk
   module Rest
     class Api
-      def initialize(rest_client:, api_key:, domain:)
+      def initialize(rest_client:, api_key:, subdomain:)
         @client = rest_client
         @api_key = api_key
-        @domain = domain
+        @subdomain = subdomain
       end
 
       def get(path)
@@ -31,7 +31,7 @@ module Freshdesk
       end
 
       def base_url
-        @base_url ||= "https://#{@domain}.freshdesk.com/api/v2".freeze
+        @base_url ||= "https://#{@subdomain}.freshdesk.com/api/v2".freeze
       end
     end
   end

--- a/lib/freshdesk-rest/client.rb
+++ b/lib/freshdesk-rest/client.rb
@@ -6,12 +6,12 @@ module Freshdesk
     class Client
       def initialize(
         api_key: Freshdesk::Rest.configuration.api_key,
-        domain: Freshdesk::Rest.configuration.domain
+        subdomain: Freshdesk::Rest.configuration.subdomain
       )
         @api = Freshdesk::Rest::Api.new(
           rest_client: RestClient,
           api_key:,
-          domain:
+          subdomain:
         )
       end
 

--- a/lib/freshdesk-rest/configuration.rb
+++ b/lib/freshdesk-rest/configuration.rb
@@ -1,11 +1,11 @@
 module Freshdesk
   module Rest
     class Configuration
-      attr_writer :api_key, :domain
+      attr_writer :api_key, :subdomain
 
       def initialize
         @api_key = nil
-        @domain = nil
+        @subdomain = nil
       end
 
       def api_key
@@ -14,9 +14,26 @@ module Freshdesk
       end
 
       def domain
-        raise 'Freshdesk domain not defined' if @domain.nil?
-        @domain
+        warn_domain_deprecated
+        @subdomain
       end
+
+      def domain=(domain)
+        warn_domain_deprecated
+        @subdomain = domain
+      end
+
+      def subdomain
+        raise 'Freshdesk subdomain not defined' if @subdomain.nil?
+        @subdomain
+      end
+
+      private
+
+        def warn_domain_deprecated
+           warn "[DEPRECATION] Freshdesk config option `domain` is deprecated. Please use `subdomain` instead."
+        end
+
     end
   end
 end

--- a/lib/freshdesk-rest/factory.rb
+++ b/lib/freshdesk-rest/factory.rb
@@ -8,7 +8,7 @@ module Freshdesk
         Freshdesk::Rest::Api.new(
           rest_client: RestClient,
           api_key: Freshdesk::Rest.configuration.api_key,
-          domain: Freshdesk::Rest.configuration.domain
+          subdomain: Freshdesk::Rest.configuration.subdomain
         )
       end
 

--- a/spec/freshdesk-rest/api_spec.rb
+++ b/spec/freshdesk-rest/api_spec.rb
@@ -5,9 +5,9 @@ require_relative '../../lib/freshdesk-rest/api'
 RSpec.describe Freshdesk::Rest::Api do
   let(:rest_client) { RestClient }
   let(:api_key)     { 'some_random_api_key' }
-  let(:domain)      { 'some_random_domain' }
-  let(:base_url)    { "https://#{domain}.freshdesk.com/api/v2" }
-  let(:service)     { described_class.new(rest_client: rest_client, api_key: api_key, domain: domain) }
+  let(:subdomain)      { 'some_random_subdomain' }
+  let(:base_url)    { "https://#{subdomain}.freshdesk.com/api/v2" }
+  let(:service)     { described_class.new(rest_client: rest_client, api_key: api_key, subdomain: subdomain) }
 
   describe '#get' do
     context 'resource is found but without content' do

--- a/spec/freshdesk-rest/client_spec.rb
+++ b/spec/freshdesk-rest/client_spec.rb
@@ -3,7 +3,7 @@ require_relative '../../lib/freshdesk-rest'
 RSpec.describe Freshdesk::Rest::Client do
   let(:api) { double('Freshdesk::Rest::Api') }
   let(:api_key) { 'SOME_FRESHDESK_API_KEY' }
-  let(:domain) { 'SOME_FRESHDESK_DOMAIN' }
+  let(:subdomain) { 'SOME_FRESHDESK_SUBDOMAIN' }
 
   before do
     allow(Freshdesk::Rest::Api).to receive(:new).and_return(api)
@@ -13,7 +13,7 @@ RSpec.describe Freshdesk::Rest::Client do
     before do
       Freshdesk::Rest.configure do |config|
         config.api_key = api_key
-        config.domain = domain
+        config.subdomain = subdomain
       end
     end
 
@@ -24,7 +24,7 @@ RSpec.describe Freshdesk::Rest::Client do
         expect(Freshdesk::Rest::Api).to have_received(:new).with(
           rest_client: RestClient,
           api_key:,
-          domain:
+          subdomain:
         )
         expect(Freshdesk::Rest::Resource::Contact).to have_received(:new).with(
           client: api
@@ -39,7 +39,7 @@ RSpec.describe Freshdesk::Rest::Client do
         expect(Freshdesk::Rest::Api).to have_received(:new).with(
           rest_client: RestClient,
           api_key:,
-          domain:
+          subdomain:
         )
         expect(Freshdesk::Rest::Resource::Company).to have_received(:new).with(
           client: api
@@ -54,7 +54,7 @@ RSpec.describe Freshdesk::Rest::Client do
         expect(Freshdesk::Rest::Api).to have_received(:new).with(
           rest_client: RestClient,
           api_key:,
-          domain:
+          subdomain:
         )
         expect(Freshdesk::Rest::Resource::Ticket).to have_received(:new).with(
           client: api
@@ -69,7 +69,7 @@ RSpec.describe Freshdesk::Rest::Client do
         expect(Freshdesk::Rest::Api).to have_received(:new).with(
           rest_client: RestClient,
           api_key:,
-          domain:
+          subdomain:
         )
         expect(Freshdesk::Rest::Resource::Solutions::Article).to have_received(:new).with(
           client: api
@@ -84,7 +84,7 @@ RSpec.describe Freshdesk::Rest::Client do
         expect(Freshdesk::Rest::Api).to have_received(:new).with(
           rest_client: RestClient,
           api_key:,
-          domain:
+          subdomain:
         )
         expect(Freshdesk::Rest::Resource::Solutions::Category).to have_received(:new).with(
           client: api
@@ -99,7 +99,7 @@ RSpec.describe Freshdesk::Rest::Client do
         expect(Freshdesk::Rest::Api).to have_received(:new).with(
           rest_client: RestClient,
           api_key:,
-          domain:
+          subdomain:
         )
         expect(Freshdesk::Rest::Resource::Solutions::Folder).to have_received(:new).with(
           client: api
@@ -112,11 +112,11 @@ RSpec.describe Freshdesk::Rest::Client do
     describe '.contact_resource' do
       it 'returns appropriate class with correct params' do
         allow(Freshdesk::Rest::Resource::Contact).to receive(:new)
-        described_class.new(api_key:, domain:).contact_resource
+        described_class.new(api_key:, subdomain:).contact_resource
         expect(Freshdesk::Rest::Api).to have_received(:new).with(
           rest_client: RestClient,
           api_key:,
-          domain:
+          subdomain:
         )
         expect(Freshdesk::Rest::Resource::Contact).to have_received(:new).with(
           client: api
@@ -127,11 +127,11 @@ RSpec.describe Freshdesk::Rest::Client do
     describe '.company_resource' do
       it 'returns appropriate class with correct params' do
         allow(Freshdesk::Rest::Resource::Company).to receive(:new)
-        described_class.new(api_key:, domain:).company_resource
+        described_class.new(api_key:, subdomain:).company_resource
         expect(Freshdesk::Rest::Api).to have_received(:new).with(
           rest_client: RestClient,
           api_key:,
-          domain:
+          subdomain:
         )
         expect(Freshdesk::Rest::Resource::Company).to have_received(:new).with(
           client: api
@@ -142,11 +142,11 @@ RSpec.describe Freshdesk::Rest::Client do
     describe '.ticket_resource' do
       it 'returns appropriate class with correct params' do
         allow(Freshdesk::Rest::Resource::Ticket).to receive(:new)
-        described_class.new(api_key:, domain:).ticket_resource
+        described_class.new(api_key:, subdomain:).ticket_resource
         expect(Freshdesk::Rest::Api).to have_received(:new).with(
           rest_client: RestClient,
           api_key:,
-          domain:
+          subdomain:
         )
         expect(Freshdesk::Rest::Resource::Ticket).to have_received(:new).with(
           client: api
@@ -157,11 +157,11 @@ RSpec.describe Freshdesk::Rest::Client do
     describe '.solutions_article_resource' do
       it 'returns appropriate class with correct params' do
         allow(Freshdesk::Rest::Resource::Solutions::Article).to receive(:new)
-        described_class.new(api_key:, domain:).solutions_article_resource
+        described_class.new(api_key:, subdomain:).solutions_article_resource
         expect(Freshdesk::Rest::Api).to have_received(:new).with(
           rest_client: RestClient,
           api_key:,
-          domain:
+          subdomain:
         )
         expect(Freshdesk::Rest::Resource::Solutions::Article).to have_received(:new).with(
           client: api
@@ -172,11 +172,11 @@ RSpec.describe Freshdesk::Rest::Client do
     describe '.solutions_category_resource' do
       it 'returns appropriate class with correct params' do
         allow(Freshdesk::Rest::Resource::Solutions::Category).to receive(:new)
-        described_class.new(api_key:, domain:).solutions_category_resource
+        described_class.new(api_key:, subdomain:).solutions_category_resource
         expect(Freshdesk::Rest::Api).to have_received(:new).with(
           rest_client: RestClient,
           api_key:,
-          domain:
+          subdomain:
         )
         expect(Freshdesk::Rest::Resource::Solutions::Category).to have_received(:new).with(
           client: api
@@ -187,11 +187,11 @@ RSpec.describe Freshdesk::Rest::Client do
     describe '.solutions_folder_resource' do
       it 'returns appropriate class with correct params' do
         allow(Freshdesk::Rest::Resource::Solutions::Folder).to receive(:new)
-        described_class.new(api_key:, domain:).solutions_folder_resource
+        described_class.new(api_key:, subdomain:).solutions_folder_resource
         expect(Freshdesk::Rest::Api).to have_received(:new).with(
           rest_client: RestClient,
           api_key:,
-          domain:
+          subdomain:
         )
         expect(Freshdesk::Rest::Resource::Solutions::Folder).to have_received(:new).with(
           client: api

--- a/spec/freshdesk-rest/configuration_spec.rb
+++ b/spec/freshdesk-rest/configuration_spec.rb
@@ -2,7 +2,7 @@ require_relative '../../lib/freshdesk-rest/configuration'
 
 RSpec.describe Freshdesk::Rest::Configuration do
   let(:key)     { double }
-  let(:dom)     { double }
+  let(:subdomain)     { double }
   let(:service) { described_class.new }
 
   describe '#api_key' do
@@ -10,32 +10,40 @@ RSpec.describe Freshdesk::Rest::Configuration do
 
     context 'pre configured' do
       before { service.api_key = key }
-      before { service.domain = dom }
+      before { service.subdomain = subdomain }
 
       it { expect(subject).to eq(key) }
     end
 
     context 'an API key is not set' do
-      before { service.domain = dom }
+      before { service.subdomain = subdomain }
 
       it { expect{subject}.to(raise_error 'Freshdesk API key not defined') }
     end
   end
 
-  describe '#domain' do
-    subject { service.domain }
+  describe '#domain=' do
+    it 'is usable but warns of deprecation' do
+      expect(service).to receive(:warn)
+      service.domain = subdomain
+      expect(service.subdomain).to eq(subdomain)
+    end
+  end
+
+  describe '#subdomain' do
+    subject { service.subdomain }
 
     context 'pre configured' do
       before { service.api_key = key }
-      before { service.domain = dom }
+      before { service.subdomain = subdomain }
 
-      it { expect(subject).to eq(dom) }
+      it { expect(subject).to eq(subdomain) }
     end
 
-    context 'an domain is not set' do
+    context 'a subdomain is not set' do
       before { service.api_key = key }
 
-      it { expect{subject}.to(raise_error 'Freshdesk domain not defined') }
+      it { expect{subject}.to(raise_error 'Freshdesk subdomain not defined') }
     end
   end
 end

--- a/spec/freshdesk-rest/factory_spec.rb
+++ b/spec/freshdesk-rest/factory_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Freshdesk::Rest::Factory do
   before do
     Freshdesk::Rest.configure do |config|
       config.api_key = 'SOME_FRESHDESK_API_KEY'
-      config.domain = 'SOME_FRESHDESK_DOMAIN'
+      config.subdomain = 'SOME_FRESHDESK_SUBDOMAIN'
     end
   end
 


### PR DESCRIPTION
# Summary

This renames the configuration option `domain` as `subdomain` to improve clarity and avoid errors. This adds backward-compatibility methods for `domain` to warn it is deprecated. This also adds a note in the README explaining what should be set.

# Problem addressed

Previously one of the two main configuration requirements was `domain`. This term is generally used for a fully qualified domain name including TLD, like "fizbuz.freshdesk.com". However, only the subdomain was actually expected, like "fizbuz". Providing a full domain caused exceptions to be raised, like `OpenSSL::SSL::SSLError` "certificate verify failed (hostname mismatch)".
